### PR TITLE
Add verbosity to HHKinFitMasterHeavyHiggs

### DIFF
--- a/HHKinFit2Scenarios/interface/HHKinFitMasterHeavyHiggs.h
+++ b/HHKinFit2Scenarios/interface/HHKinFitMasterHeavyHiggs.h
@@ -38,7 +38,8 @@ class HHKinFitMasterHeavyHiggs{
                            TVector2 const& met, TMatrixD const& met_cov,
                            double sigmaEbjet1 = -1.0, double sigmaEbjet2 = -1.0,
                            bool istruth=false,
-                           TLorentzVector const& higgsgen=TLorentzVector(0,0,0,0));
+                           TLorentzVector const& higgsgen=TLorentzVector(0,0,0,0),
+                           int verbosity = 1);
   
   //the main action, runs over all hypotheses and performs the fit
   void fit();
@@ -92,6 +93,12 @@ class HHKinFitMasterHeavyHiggs{
   
   double getBJet1Resolution(){return m_sigma_bjet1;};
   double getBJet2Resolution(){return m_sigma_bjet2;};
+
+  // set verbosity level (0 - mute, 1 - print warning)
+  void setVerbosity(int aVerbosity);
+
+  /// get verbosity level
+  int getVerbosity() const;
 
   //DEPRECATED/////////////////////////////////////////////////////////
   //only here for backwards compatibility
@@ -157,6 +164,9 @@ private:
   //For ToyMC Studies
   TMatrixD m_bjet1_COV;
   TMatrixD m_bjet2_COV;
+
+  // Verbosity
+  int m_verbosity;
 };
 }
 #endif

--- a/HHKinFit2Scenarios/src/HHKinFitMasterHeavyHiggs.cpp
+++ b/HHKinFit2Scenarios/src/HHKinFitMasterHeavyHiggs.cpp
@@ -33,7 +33,8 @@ HHKinFit2::HHKinFitMasterHeavyHiggs::HHKinFitMasterHeavyHiggs(TLorentzVector con
                                                               double sigmaEbjet1,
                                                               double sigmaEbjet2,
                                                               bool istruth, 
-                                                              TLorentzVector const&  heavyhiggsgen)
+                                                              TLorentzVector const& heavyhiggsgen,
+                                                              int verbosity)
   :m_MET_COV(TMatrixD(4,4)), m_bjet1_COV(TMatrixD(4,4)), m_bjet2_COV(TMatrixD(4,4))
 {
   m_bjet1 = HHLorentzVector(bjet1.Px(), bjet1.Py(), 
@@ -201,6 +202,9 @@ HHKinFit2::HHKinFitMasterHeavyHiggs::HHKinFitMasterHeavyHiggs(TLorentzVector con
     //m_MET_COV = recoil_COV + bjet1Cov + bjet2Cov;
     m_MET_COV = recoil_COV;
   }  
+
+  // verbosity
+  m_verbosity = verbosity;
 }
 
 
@@ -258,9 +262,12 @@ void HHKinFit2::HHKinFitMasterHeavyHiggs::fit()
     }
     catch(HHLimitSettingException const& e)
     {
-      std::cout << "Exception while setting tau limits:" << std::endl;
-      std::cout << e.what() << std::endl;
-      std::cout << "Tau energies are not compatible with invariant mass constraint." << std::endl;
+      if (m_verbosity >=1)
+      {
+        std::cout << "Exception while setting tau limits:" << std::endl;
+        std::cout << e.what() << std::endl;
+        std::cout << "Tau energies are not compatible with invariant mass constraint." << std::endl;
+      }
 
       m_map_chi2[m_hypos[i]] = -pow(10,10);
       m_map_prob[m_hypos[i]] = -pow(10,10);
@@ -1087,6 +1094,10 @@ TLorentzVector HHKinFit2::HHKinFitMasterHeavyHiggs::getFittedBJet2(int mh1, int 
   HHFitHypothesisHeavyHiggs hypo(mh1, mh2);
   return(m_map_fittedB2[hypo]);
 }
+
+void HHKinFit2::HHKinFitMasterHeavyHiggs::setVerbosity(int aVerbosity) {m_verbosity = aVerbosity;}
+
+int HHKinFit2::HHKinFitMasterHeavyHiggs::getVerbosity() const {return m_verbosity;}
 
 void HHKinFit2::HHKinFitMasterHeavyHiggs::setAdvancedBalance(const TLorentzVector* met, 
                                                              TMatrixD met_cov)


### PR DESCRIPTION
#### PR Description
In this PR I'm adding a `verbosity` parameter to the `HHKinFitMasterHeavyHiggs` class. This parameter is set to `1` by default, thus preserving the original behavior of the class.

When set to `0`, using the newly added `setVerbosity()` method, it silences the warnings which are currently flooding the CCLUB logs.

#### PR Validation
Tested with verbosity set to both 0 and 1 and verified the expected behavior.